### PR TITLE
Remove abq-token now that access-token is required

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,16 +3,6 @@ on:
   - push
 
 jobs:
-  test_with_abq_token__deprecated:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: ./
-      with:
-        abq-token: ${{ secrets.RWX_ACCESS_TOKEN }}
-    - run: |
-        abq help
-
   test:
     runs-on: ubuntu-latest
     steps:

--- a/dist/index.js
+++ b/dist/index.js
@@ -6603,7 +6603,7 @@ function getRunId() {
 }
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
-        const accessToken = core.getInput('access-token') || core.getInput('abq-token');
+        const accessToken = core.getInput('access-token');
         const releaseChannel = 'v1';
         const os = getOs();
         const arch = getArch();

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,7 @@ function getRunId() {
 }
 
 async function run() {
-  const accessToken =
-    core.getInput('access-token') || core.getInput('abq-token')
+  const accessToken = core.getInput('access-token')
   const releaseChannel = 'v1'
   const os = getOs()
   const arch = getArch()


### PR DESCRIPTION
I missed this in https://github.com/rwx-research/setup-abq/pull/7