### PR TITLE
Allow release-channel and run-id inputs.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,3 +13,13 @@ inputs:
       RWX Access Token.
       See https://www.rwx.com/docs/access-tokens
     required: true
+  release-channel:
+    description: |
+      ABQ Release Channel.
+    required: false
+    default: v1
+  run-id:
+    description: |
+      Unique run attempt ID. One will be generated from the GitHub
+      RUN_ID and RUN_ATTEMPT if available.
+    required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -6597,6 +6597,10 @@ function getArch() {
     }
 }
 function getRunId() {
+    const providedRunId = core.getInput('run-id');
+    if (providedRunId && providedRunId.trim().length > 0) {
+        return providedRunId.trim();
+    }
     const runId = process.env.GITHUB_RUN_ID;
     const runAttempt = process.env.GITHUB_RUN_ATTEMPT || '1';
     return `${runId}-${runAttempt}`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-abq",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "description": "This action installs the abq binary.",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,11 @@ function getArch() {
 }
 
 function getRunId() {
+  const providedRunId = core.getInput('run-id')
+  if (providedRunId && providedRunId.trim().length > 0) {
+    return providedRunId.trim()
+  }
+
   const runId = process.env.GITHUB_RUN_ID
   const runAttempt = process.env.GITHUB_RUN_ATTEMPT || '1'
 


### PR DESCRIPTION
I'd like to test these out more thoroughly before adding `run-id` to the README. I'll follow up once that's done.