### PR TITLE
install raw abq instead of compressed abq

### DIFF
--- a/.github/workflows/continuous_integration.yaml
+++ b/.github/workflows/continuous_integration.yaml
@@ -2,8 +2,8 @@ name: Continuous Integration
 on:
   push:
 jobs:
-  type-check:
-    name: Type check
+  test-dist-checked-in:
+    name: Test that build passes & updated dist/index.js is checked in
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -13,10 +13,8 @@ jobs:
             keep-derivations = true
             keep-outputs = true
       - run: |
-          mv dist/index.js dist/index.old.$GITHUB_RUN_ID.$GITHUB_RUN_NUMBER.js
           nix develop --command npm clean-install
-          nix develop --command npm run build
-          diff dist/index.old.$GITHUB_RUN_ID.$GITHUB_RUN_NUMBER.js dist/index.js
+          nix develop --command npm run build-check
 
   test_default_version:
     runs-on: ubuntu-latest
@@ -38,5 +36,5 @@ jobs:
             keep-derivations = true
             keep-outputs = true
       - run: nix develop --command npm clean-install
-      - run: nix develop --command npx prettier --check "src/**/*.ts"
+      - run: nix develop --command npm run lint-check
       - run: nix fmt -- --check flake.nix

--- a/dist/index.js
+++ b/dist/index.js
@@ -6578,6 +6578,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const core = __importStar(__nccwpck_require__(2186));
+const exec = __importStar(__nccwpck_require__(1514));
 const tc = __importStar(__nccwpck_require__(7784));
 function getOs() {
     switch (process.platform) {
@@ -6614,14 +6615,18 @@ function run() {
         const os = getOs();
         const arch = getArch();
         const installId = getInstallId();
-        const downloadUrl = `https://abq.build/api/releases/${releaseChannel}?os=${os}&arch=${arch}&install_id=${installId}`;
-        core.debug(`fetching ${downloadUrl}`);
-        const abqTar = yield tc.downloadTool(downloadUrl, 
+        const url = `https://abq.build/api/releases/${releaseChannel}/${os}/${arch}/abq?install_id=${installId}`;
+        core.debug(`Fetching ${url}`);
+        const abq = yield tc.downloadTool(url, 
         /* dest */ undefined, `Bearer ${accessToken}`);
-        const abqFolder = yield tc.extractTar(abqTar, 
-        /* dest */ undefined, 
-        /* flags */ ['-xv', '--strip-components=1']);
-        core.addPath(abqFolder);
+        const destination = '/usr/local/bin/abq';
+        core.debug(`Installing to ${destination}`);
+        yield exec.exec('install', [abq, destination]);
+        const { stdout } = yield exec.getExecOutput('abq', ['--version'], {
+            silent: true
+        });
+        const cliVersion = stdout.replace('\n', '');
+        core.info(`abq ${cliVersion} is installed`);
     });
 }
 run().catch(err => core.setFailed(err));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-abq",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-abq",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-abq",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "description": "This action installs the abq binary.",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "description": "This action installs the abq binary.",
   "main": "dist/index.js",
   "scripts": {
-    "build": "ncc build -o dist src/index.ts"
+    "build": "ncc build -o dist src/index.ts",
+    "build-check": "npm run build && test -z \"$(git status --porcelain)\"",
+    "lint": "npx prettier --write 'src/**/*.ts'",
+    "lint-check": "npx prettier --check 'src/**/*.ts'",
+    "test": "npm run lint-check && npm run build-check"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
this PR
- consumes a new API to download abq
- adds some of the CI scripts

## ✅BEFORE MERGE:
- [x] ensure all the current abq binaries are available in the new API (they are!)