### PR TITLE
incorporate release channel into install id to support multiple release channels from the same build

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6597,10 +6597,10 @@ function getArch() {
         }
     }
 }
-function getInstallId() {
+function getInstallId(releaseChannel) {
     const runId = process.env.GITHUB_RUN_ID;
     const runAttempt = process.env.GITHUB_RUN_ATTEMPT || '1';
-    return `${runId}-${runAttempt}`;
+    return `${runId}-${runAttempt}-${releaseChannel}`;
 }
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -6614,7 +6614,7 @@ function run() {
         }
         const os = getOs();
         const arch = getArch();
-        const installId = getInstallId();
+        const installId = getInstallId(releaseChannel);
         const url = `https://abq.build/api/releases/${releaseChannel}/${os}/${arch}/abq?install_id=${installId}`;
         core.debug(`Fetching ${url}`);
         const abq = yield tc.downloadTool(url, 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-abq",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-abq",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-abq",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "description": "This action installs the abq binary.",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,11 +21,11 @@ function getArch() {
   }
 }
 
-function getInstallId() {
+function getInstallId(releaseChannel: string) {
   const runId = process.env.GITHUB_RUN_ID
   const runAttempt = process.env.GITHUB_RUN_ATTEMPT || '1'
 
-  return `${runId}-${runAttempt}`
+  return `${runId}-${runAttempt}-${releaseChannel}`
 }
 
 async function run() {
@@ -42,7 +42,7 @@ async function run() {
   }
   const os = getOs()
   const arch = getArch()
-  const installId = getInstallId()
+  const installId = getInstallId(releaseChannel)
 
   const url = `https://abq.build/api/releases/${releaseChannel}/${os}/${arch}/abq?install_id=${installId}`
 


### PR DESCRIPTION
this allows `setup-abq` to be in a job with multiple release channels

Before this, the second `setup-abq` in a matrix with multiple release channels tries to use the first `setup-abq`'s install id and sees a conflict.