### PR TITLE
Update abq api to cloud host

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6614,7 +6614,7 @@ function run() {
         const os = getOs();
         const arch = getArch();
         const installId = getInstallId(releaseChannel);
-        const url = `https://abq.build/api/releases/${releaseChannel}/${os}/${arch}/abq?install_id=${installId}`;
+        const url = `https://cloud.rwx.com/abq/api/releases/${releaseChannel}/${os}/${arch}/abq?install_id=${installId}`;
         core.debug(`Fetching ${url}`);
         const abq = yield tc.downloadTool(url, 
         /* dest */ undefined, `Bearer ${accessToken}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-abq",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-abq",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-abq",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true,
   "description": "This action installs the abq binary.",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ async function run() {
   const arch = getArch()
   const installId = getInstallId(releaseChannel)
 
-  const url = `https://abq.build/api/releases/${releaseChannel}/${os}/${arch}/abq?install_id=${installId}`
+  const url = `https://cloud.rwx.com/abq/api/releases/${releaseChannel}/${os}/${arch}/abq?install_id=${installId}`
 
   core.debug(`Fetching ${url}`)
   const abq = await tc.downloadTool(


### PR DESCRIPTION
First contrib to this repo. I generated dist using `npm run build` and bumped the package version -- let me know if there's more or less to be done :)