### PR TITLE
Update action to use node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   icon: database
   color: green
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 inputs:
   access-token:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-abq",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-abq",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "1.10.0",
@@ -17,7 +17,7 @@
         "@babel/preset-env": "7.19.4",
         "@babel/preset-typescript": "7.18.6",
         "@types/jest": "29.1.2",
-        "@types/node": "18.7.10",
+        "@types/node": "^20.11.10",
         "@types/uuid": "8.3.4",
         "@typescript-eslint/eslint-plugin": "5.40.0",
         "@typescript-eslint/parser": "5.40.0",
@@ -32,6 +32,9 @@
         "js-yaml": "4.1.0",
         "prettier": "2.7.1",
         "typescript": "4.8.4"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@actions/core": {
@@ -2115,13 +2118,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/console/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@jest/core": {
       "version": "29.2.1",
       "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.2.1.tgz",
@@ -2170,13 +2166,6 @@
         }
       }
     },
-    "node_modules/@jest/core/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@jest/environment": {
       "version": "29.2.1",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.2.1.tgz",
@@ -2192,13 +2181,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/@jest/environment/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@jest/expect": {
       "version": "29.2.1",
@@ -2244,13 +2226,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/@jest/fake-timers/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@jest/globals": {
       "version": "29.2.1",
@@ -2311,13 +2286,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@jest/reporters/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@jest/schemas": {
       "version": "29.0.0",
@@ -2454,13 +2422,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/@jest/types/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.1.1",
@@ -2634,13 +2595,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/graceful-fs/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -2694,11 +2648,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.7.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.10.tgz",
-      "integrity": "sha512-SST7B//wF7xlGoLo1IEVB0cQ4e7BgXlDk5IaPgb5s0DlYLjb4if07h8+0zbQIvahfPNXs6e7zyT0EH1MqaS+5g==",
+      "version": "20.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
+      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.1",
@@ -5979,13 +5935,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-circus/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jest-cli": {
       "version": "29.2.1",
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.2.1.tgz",
@@ -6098,13 +6047,6 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/jest-config/node_modules/@types/node": {
-      "version": "18.11.3",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/jest-config/node_modules/babel-jest": {
       "version": "29.2.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.2.1.tgz",
@@ -6191,13 +6133,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-environment-node/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jest-get-type": {
       "version": "29.2.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.2.0.tgz",
@@ -6233,13 +6168,6 @@
       "optionalDependencies": {
         "fsevents": "^2.3.2"
       }
-    },
-    "node_modules/jest-haste-map/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/jest-junit": {
       "version": "14.0.1",
@@ -6332,13 +6260,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/jest-mock/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.2",
@@ -6436,13 +6357,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-runner/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jest-runtime": {
       "version": "29.2.1",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.2.1.tgz",
@@ -6476,13 +6390,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/jest-runtime/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/jest-runtime/node_modules/strip-bom": {
       "version": "4.0.0",
@@ -6621,13 +6528,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-util/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jest-validate": {
       "version": "29.2.1",
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.2.1.tgz",
@@ -6679,13 +6579,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-watcher/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/jest-worker": {
       "version": "29.2.1",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.2.1.tgz",
@@ -6701,13 +6594,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/jest-worker/node_modules/@types/node": {
-      "version": "18.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-      "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/jest-worker/node_modules/supports-color": {
       "version": "8.1.1",
@@ -8262,6 +8148,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -9941,14 +9833,6 @@
         "jest-message-util": "^29.2.1",
         "jest-util": "^29.2.1",
         "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        }
       }
     },
     "@jest/core": {
@@ -9985,14 +9869,6 @@
         "pretty-format": "^29.2.1",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        }
       }
     },
     "@jest/environment": {
@@ -10005,14 +9881,6 @@
         "@jest/types": "^29.2.1",
         "@types/node": "*",
         "jest-mock": "^29.2.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        }
       }
     },
     "@jest/expect": {
@@ -10046,14 +9914,6 @@
         "jest-message-util": "^29.2.1",
         "jest-mock": "^29.2.1",
         "jest-util": "^29.2.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        }
       }
     },
     "@jest/globals": {
@@ -10098,14 +9958,6 @@
         "string-length": "^4.0.1",
         "strip-ansi": "^6.0.0",
         "v8-to-istanbul": "^9.0.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        }
       }
     },
     "@jest/schemas": {
@@ -10212,14 +10064,6 @@
         "@types/node": "*",
         "@types/yargs": "^17.0.8",
         "chalk": "^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        }
       }
     },
     "@jridgewell/gen-mapping": {
@@ -10358,14 +10202,6 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        }
       }
     },
     "@types/istanbul-lib-coverage": {
@@ -10415,10 +10251,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.7.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.10.tgz",
-      "integrity": "sha512-SST7B//wF7xlGoLo1IEVB0cQ4e7BgXlDk5IaPgb5s0DlYLjb4if07h8+0zbQIvahfPNXs6e7zyT0EH1MqaS+5g==",
-      "dev": true
+      "version": "20.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.10.tgz",
+      "integrity": "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/prettier": {
       "version": "2.7.1",
@@ -12542,14 +12381,6 @@
         "pretty-format": "^29.2.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        }
       }
     },
     "jest-cli": {
@@ -12625,12 +12456,6 @@
             "semver": "^6.3.0"
           }
         },
-        "@types/node": {
-          "version": "18.11.3",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
         "babel-jest": {
           "version": "29.2.1",
           "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.2.1.tgz",
@@ -12694,14 +12519,6 @@
         "@types/node": "*",
         "jest-mock": "^29.2.1",
         "jest-util": "^29.2.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        }
       }
     },
     "jest-get-type": {
@@ -12728,14 +12545,6 @@
         "jest-worker": "^29.2.1",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        }
       }
     },
     "jest-junit": {
@@ -12806,14 +12615,6 @@
         "@jest/types": "^29.2.1",
         "@types/node": "*",
         "jest-util": "^29.2.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        }
       }
     },
     "jest-pnp-resolver": {
@@ -12883,14 +12684,6 @@
         "jest-worker": "^29.2.1",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        }
       }
     },
     "jest-runtime": {
@@ -12923,12 +12716,6 @@
         "strip-bom": "^4.0.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        },
         "strip-bom": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
@@ -13032,14 +12819,6 @@
         "ci-info": "^3.2.0",
         "graceful-fs": "^4.2.9",
         "picomatch": "^2.2.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        }
       }
     },
     "jest-validate": {
@@ -13078,14 +12857,6 @@
         "emittery": "^0.10.2",
         "jest-util": "^29.2.1",
         "string-length": "^4.0.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        }
       }
     },
     "jest-worker": {
@@ -13100,12 +12871,6 @@
         "supports-color": "^8.0.0"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "18.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.3.tgz",
-          "integrity": "sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==",
-          "dev": true
-        },
         "supports-color": {
           "version": "8.1.1",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -14146,6 +13911,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-abq",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "private": true,
   "description": "This action installs the abq binary.",
   "main": "dist/index.js",
@@ -22,6 +22,9 @@
   ],
   "author": "rwx",
   "license": "MIT",
+  "engines": {
+    "node": ">= 20"
+  },
   "dependencies": {
     "@actions/core": "1.10.0",
     "@actions/tool-cache": "^2.0.1"
@@ -31,7 +34,7 @@
     "@babel/preset-env": "7.19.4",
     "@babel/preset-typescript": "7.18.6",
     "@types/jest": "29.1.2",
-    "@types/node": "18.7.10",
+    "@types/node": "^20.11.10",
     "@types/uuid": "8.3.4",
     "@typescript-eslint/eslint-plugin": "5.40.0",
     "@typescript-eslint/parser": "5.40.0",


### PR DESCRIPTION
GitHub has deprecated Node 16 in Actions. Workflows using this action are throwing a deprecation warning since it's using Node 16

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20