### PR TITLE
Map arm64 to aarch64

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28618,7 +28618,10 @@ function getOs() {
 function getArch() {
     switch (process.arch) {
         case 'x64': {
-            return 'x86-64';
+            return 'x86_64';
+        }
+        case 'arm64': {
+            return 'aarch64';
         }
         default: {
             return process.arch;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "setup-abq",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "setup-abq",
-      "version": "1.0.31",
+      "version": "1.0.32",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-abq",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "private": true,
   "description": "This action installs the abq binary.",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,10 @@ function getOs() {
 function getArch() {
   switch (process.arch) {
     case 'x64': {
-      return 'x86-64'
+      return 'x86_64'
+    }
+    case 'arm64': {
+      return 'aarch64'
     }
     default: {
       return process.arch


### PR DESCRIPTION
The docs for `process.arch` state:

```
Possible values are: 'arm', 'arm64', 'ia32', 'loong64', 'mips', 'mipsel', 'ppc', 'ppc64', 'riscv64', 's390', 's390x', and 'x64'.
```

I think for now, we should just handle mapping these gradually as we learn more about usage. The only other one I suspect we may care about is `arm` (without the `64` suffix), but I'm not clear on how it differs.